### PR TITLE
Fix buffer encoded as utf8 string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,6 +82,9 @@ var queryParser = (function() {
         return quote(x);
       }
     }
+    if (x instanceof Buffer) {
+      return '0x' + x.toString('hex');
+    }
     // Numbers, TODO add a flag to make these 'pure'? or just rely on Int64?
     if (/\d+/.test(x)){
       return x.toString();
@@ -96,9 +99,6 @@ var queryParser = (function() {
       else if (x.hint === 'map') {
         return stringifyMap(x.value);
       }
-    }
-    if (x instanceof Buffer) {
-      return '0x' + x.toString('hex');
     }
     // Assume all other objects must be collections of some kind
     if (typeof x === 'object'){


### PR DESCRIPTION
Any buffer param passed to utils.queryParser.encodeParam that contains a utf8 digit will match the /\d+/ regex, and will be returned as toString(), when it should be returned as toString('hex').

ie:

``` javascript
utils.queryParser.encodeParam(new Buffer([0x30, 0x97])) 
```

returns 0ï¿½ when it should return 0x3097
