### PR TITLE
We rely on async.each, which didn't exist until 0.2.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "async": ">= 0.1.12",
+    "async": ">= 0.2.5",
     "node-int64": ">= 0.3.0",
     "node-uuid": "1.4.0"
   },


### PR DESCRIPTION
https://github.com/caolan/async/commit/1fecb21940135b2ff647a93d1fc83df03b363714#diff-688ede0ee2da1fa3d89f2fc485f39273
