### PR TITLE
Prepare query again when expired from the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,6 +281,15 @@ Client.prototype._executeOnConnection = function (c, query, queryId, params, con
       //retry the whole thing, it will get another connection
       self.executeAsPrepared(query, params, consistency, options, callback);
     }
+    else if (err && err.code === types.responseErrorCodes.unprepared) {
+      //Query expired at the server
+      //Clear the connection from prepared info and
+      //trying to re-prepare query
+      self.emit('log', 'info', 'Unprepared query "' + query + '"');
+      var preparedInfo = self.preparedQueries[query];
+      preparedInfo.removeConnectionInfo(c.indexInPool);
+      self.executeAsPrepared(query, params, consistency, callback);
+    }
     else {
       callback(err, result1, result2);
     }


### PR DESCRIPTION
When I got unprepared error, the driver continue to fail because query caches are still in client.preparedQueries.

I got below error when queries evicted from cassandra.

ResponseError: Prepared query with ID 47254fc9ab8211a7eec66ad761dbaf7e not found (either the query was not prepared on this host (maybe the host has been restarted?) or you have prepared too many queries and it has been evicted from the internal cache)
