### PR TITLE
Allow undefined values in CQL query args and translate them to NULL

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -100,6 +100,7 @@ var queryParser = (function() {
 
     var q = 0;
     var a = 0;
+    var len = args.length;
     var str = '';
 
     try {
@@ -108,7 +109,7 @@ var queryParser = (function() {
         q = query.indexOf('?', q);
         if (q >= 0) {
           str += query.substr(oldq, q-oldq);
-          if (args[a] === undefined) {
+          if (a >= len) {
             throw new QueryParserError('Query parameter number ' + (a+1) + ' is not defined. Placeholder for not provided argument.');
           }
           str += typeEncoder.stringifyValue(args[a++]);
@@ -503,7 +504,7 @@ var typeEncoder = (function(){
    * Converts a value to string for a query
    */
   function stringifyValue (item) {
-    if (item === null) {
+    if (item === null || item === undefined) {
       return 'NULL';
     }
     var value = item;
@@ -518,7 +519,7 @@ var typeEncoder = (function(){
         subtype = typeInfo.subtype;
       }
     }
-    if (value === null) {
+    if (value === null || value === undefined) {
       return 'NULL';
     }
     if (!type) {


### PR DESCRIPTION
Rather than checking for undefined values in the args array, check that the index exists, and treat undefined values as nulls.

This allows you to automatically treat non-existing members in source data as NULLs when doing inserts, e.g.

// incoming: { id: 1, field1: 'value' }
client.execute('UPDATE data SET field1=?, field2=? WHERE id=?', [incoming.field1, incoming.field2, incoming.id], callback);

Signed-off-by: Daniel Smedegaard Buus danielbuus@gmail.com
