### PR TITLE
Forward errors to emit from stream on more types of query errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,6 +258,9 @@ Client.prototype.executeAsPrepared = function () {
       //its syntax or other normal error
       utils.fixStack(stackContainer.stack, err);
       err.query = args.query;
+      if (args.options && args.options.resultStream) {
+        args.options.resultStream.emit('error', err);
+      }
       args.callback(err);
     }
     else {

--- a/test/clientTests.js
+++ b/test/clientTests.js
@@ -560,6 +560,18 @@ describe('Client', function () {
       });
     });
 
+    it('bad query should emit a ResponseError', function (done) {
+      var counter = 0;
+      var stream = client.stream('SELECT SHOULD FAIL', function (err) {
+        assert.ok(err, 'It should callback with error');
+        if (++counter === 2) done();
+      });
+      stream.on('error', function (err) {
+        assert.strictEqual(err.name, 'ResponseError');
+        if (++counter === 2) done();
+      });
+    });
+
     it('should be optional to provide a callback', function (done) {
       var rows = [];
       client.stream(selectInQuery, [200, 201, 202, -1])


### PR DESCRIPTION
`.stream` errors that happen before the stream work begins aren't getting forwarded to the stream's error handlers.

I noticed this because providing a callback to a stream constructor isn't typical, so I only had the `.on('error', ...)` handler which wasn't being triggered with the query error I had.

Forward the errors, and provided a test that fails without the fix.
