### PR TITLE
Encode undefined value as null

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -109,7 +109,7 @@ var encoder = (function(){
   }
 
   function encode (item) {
-    if (item === null) {
+    if (item === null || item === undefined) {
       return null;
     }
     var value = item;
@@ -124,7 +124,7 @@ var encoder = (function(){
         subtype = typeInfo.subtype;
       }
     }
-    if (value === null) {
+    if (value === null || value === undefined) {
       return null;
     }
     if (!type) {

--- a/test/basicTests.js
+++ b/test/basicTests.js
@@ -70,7 +70,14 @@ describe('encoder', function () {
       var decoded = typeEncoder.decode(encoded, [dataTypes.set, [dataTypes.text]]);
       assert.strictEqual(util.inspect(decoded), util.inspect(value));
     });
-  })
+
+    it('should encode undefined as null', function () {
+      var hinted = typeEncoder.encode({hint: 'set<text>', value: undefined});
+      var unhinted = typeEncoder.encode();
+      assert.strictEqual(hinted, null);
+      assert.strictEqual(unhinted, null);
+    });
+  });
 });
 
 describe('types', function () {


### PR DESCRIPTION
Same as previously, this time with a test case, too ;)

Was also wondering if you'd accept a pull request for an attempt at casting values to their supposed type on mismatch in the encoder functions before throwing a type error? — e.g. in encodeInt, instead of

```
if (typeof value !== 'number') {
  throw new TypeError(null, value, 'number');
}
```

then

```
if (typeof value !== 'number') {
  value = +value;
  if (typeof value !== 'number') {
    throw new TypeError(null, value, 'number');
  }
}
```

In 0.4.4 I don't get type errors for a hinted string integer, in 0.5.0 I do. It'd be nice to try a cast before erroring out. Would you accept a pull request with such changes?

Thanks :)
