### PR TITLE
Attempt casting of simple number types before throwing TypeError

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -281,7 +281,7 @@ var encoder = (function(){
 
   function encodeString (value, encoding) {
     if (typeof value !== 'string') {
-      throw new TypeError(null, value, 'string');
+      value += '';
     }
     return new Buffer(value, encoding);
   }

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -208,7 +208,10 @@ var encoder = (function(){
 
   function encodeInt (value) {
     if (typeof value !== 'number') {
-      throw new TypeError(null, value, 'number');
+      value = +value;
+      if (typeof value !== 'number') {
+        throw new TypeError(null, value, 'number');
+      }
     }
     var buf = new Buffer(4);
     buf.writeInt32BE(value, 0);
@@ -217,7 +220,10 @@ var encoder = (function(){
 
   function encodeFloat (value) {
     if (typeof value !== 'number') {
-      throw new TypeError(null, value, 'number');
+      value = parseFloat(value);
+      if (typeof value !== 'number') {
+        throw new TypeError(null, value, 'number');
+      }
     }
     var buf = new Buffer(4);
     buf.writeFloatBE(value, 0);
@@ -226,7 +232,10 @@ var encoder = (function(){
 
   function encodeDouble (value) {
     if (typeof value !== 'number') {
-      throw new TypeError(null, value, 'number');
+      value = parseFloat(value);
+      if (typeof value !== 'number') {
+        throw new TypeError(null, value, 'number');
+      }
     }
     var buf = new Buffer(8);
     buf.writeDoubleBE(value, 0);

--- a/test/basicTests.js
+++ b/test/basicTests.js
@@ -77,6 +77,28 @@ describe('encoder', function () {
       assert.strictEqual(hinted, null);
       assert.strictEqual(unhinted, null);
     });
+
+
+    it('should encode hinted integer strings as integers', function () {
+      var value = '1';
+      var encoded = typeEncoder.encode({hint: 'int', value: value});
+      var decoded = typeEncoder.decode(encoded, [dataTypes.int]);
+      assert.strictEqual(decoded, +value);
+    });
+
+    it('should encode hinted float strings as floats', function () {
+      var value = '1.07';
+      var encoded = typeEncoder.encode({hint: 'float', value: value});
+      var decoded = typeEncoder.decode(encoded, [dataTypes.float]);
+      assert.strictEqual(Math.round(decoded*100), 107);
+    });
+
+    it('should encode hinted double strings as doubles', function () {
+      var value = '1.07';
+      var encoded = typeEncoder.encode({hint: 'double', value: value});
+      var decoded = typeEncoder.decode(encoded, [dataTypes.double]);
+      assert.strictEqual(Math.round(decoded*100), 107);
+    });
   });
 });
 


### PR DESCRIPTION
Okay, so to continue the conversation :)

At the moment (in v0.5.0), if I do:

```
client.execute('SELECT * FROM cf WHERE intField = ?', ['1'], function () {});
```

Then NCC will guess the '1' value to be an integer, and call encodeInt(1), and everything goes according to plan.

If, however, I do:

```
client.execute('SELECT * FROM cf WHERE intField = ?', [{hint:'int', value:'1'}], function () {});
```

Then NCC will look at the hint and call encodeInt('1'), which will throw a TypeError, because of the string.

In other words: If we don't specify what we're sending, NCC will first try to guess what the type is, and then proceed accordingly if successful at doing so.

But if we DO specify what we're sending (or in this case, meaning to send ;) ), then we will be "penalized" for explicitly defining the schema type, and the code will fail.

I acknowledge there's a point in teaching people like me to sanitize their data :), but there are three reasons why I think this patch makes sense:

1) There's no type guessing going on that wasn't going on before. This only applies to cases where a hint is given. You might think of it as a service.
2) The behavior in 0.4.4 is to not throw an error, and thus those of us with "unsanitary" data won't have failures when upgrading.
3) There's no performance penalty at all. The casting is only performed when we'd otherwise throw a TypeError and die.

So ... If I'm not wrong in all of that (and I may be ;) ), then I hope you agree :dancers: 

Cheers,
Daniel :)
