### PR TITLE
Added a more descriptive error message for encodeInt/Float/Double

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -208,7 +208,7 @@ var encoder = (function(){
 
   function encodeInt (value) {
     if (typeof value !== 'number') {
-      throw new TypeError(null, value, 'number');
+      throw new TypeError("encodeInt failed: typeof value !== 'number'", value, 'number');
     }
     var buf = new Buffer(4);
     buf.writeInt32BE(value, 0);
@@ -217,7 +217,7 @@ var encoder = (function(){
 
   function encodeFloat (value) {
     if (typeof value !== 'number') {
-      throw new TypeError(null, value, 'number');
+      throw new TypeError("encodeFloat failed: typeof value !== 'number'", value, 'number');
     }
     var buf = new Buffer(4);
     buf.writeFloatBE(value, 0);
@@ -226,7 +226,7 @@ var encoder = (function(){
 
   function encodeDouble (value) {
     if (typeof value !== 'number') {
-      throw new TypeError(null, value, 'number');
+      throw new TypeError("encodeDouble failed: typeof value !== 'number'", value, 'number');
     }
     var buf = new Buffer(8);
     buf.writeDoubleBE(value, 0);


### PR DESCRIPTION
I usually print out the error as a string, and previously it output null. I'd much rather have it output something that is more representative of what actually went wrong.
