### PR TITLE
Remove 10ms delay when one C* node is down

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,9 +152,9 @@ Client.prototype._getAConnection = function (callback) {
           if (err) {
             //This connection is still not good, go for the next one
             self._setUnhealthy(c);
-            setTimeout(function () {
+            setImmediate(function() {
               checkNextConnection(callback);
-            }, 10);
+            });
           }
           else {
             //this connection is now good
@@ -165,9 +165,9 @@ Client.prototype._getAConnection = function (callback) {
       }
       else {
         //this connection is not good, try the next one
-        setTimeout(function () {
+        setImmediate(function() {
           checkNextConnection(callback);
-        }, 10);
+        });
       }
     }
     checkNextConnection(callback);

--- a/test/clientTests.js
+++ b/test/clientTests.js
@@ -136,7 +136,7 @@ describe('Client', function () {
       ],
       //all finished
       function(err, results){
-        assert.strictEqual(err, null, err);
+        assert.equal(err, null, err);
         assert.ok(results[1], 'The result of a query must not be null nor undefined');
         done();
       });


### PR DESCRIPTION
the checkNextConnection used setTimeout() to call checkNextConnection
on a 10ms delay. This is not needed and its better replaced with
setImmediate().

setImmediate was introduced in node 0.10 which is already the
minimal requirements in package.js so this should not break
backward compatibility.

Here's a screenshot from production environment where the patch was applied. The blue graph shows mean time to complete one SELECT operation and the green graph shows how long the longest 10% of those SELECT operations took. I'm still not totally happy because the dropped cassandra node still causes additional delay to the requests but this patch at least eliminates some of that latency. 
![remove10msdelaywhennodeisdown](https://cloud.githubusercontent.com/assets/381921/3037221/53612500-e0ba-11e3-9a22-584499113505.png)

The tests did not pass because the err was undefined instead of null so I changed the strictEqual to equal. All tests passed after this change.
