### PR TITLE
Mark connection as unhealthy when disconnected

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -48,6 +48,7 @@ Connection.prototype.createSocket = function() {
   
   this.netClient.on('close', function() {
     self.emit('log', 'info', 'Socket disconnected');
+    self.unhealthyAt = new Date().getTime();
     self.connected = false;
     self.connecting = false;
     self.invokePendingCallbacks();


### PR DESCRIPTION
This commit fix the following problem :
- use a haproxy between node-cassandra-cql and cassandra
- set timeout in haproxy
- wait lot of time without activity. Haproxy will kill unused connection.
- send some cql requests
  => All requests will fail

This is probably not the best way to fix the problem, but it's works. Let me known if there is a better solution.
